### PR TITLE
[authorization] Remove classes from documentation TOC. Fixes JB#55667

### DIFF
--- a/doc/amber-web-authorization.qdocconf
+++ b/doc/amber-web-authorization.qdocconf
@@ -30,8 +30,8 @@ qhp.AmberWebAuthorization.customFilters.AmberWebAuthorization.filterAttributes =
 
 qhp.AmberWebAuthorization.subprojects = overview qmltypes classes
 
-qhp.AmberWebAuthorization.subprojects.overview.title = Amber Web Authorization Framework
-qhp.AmberWebAuthorization.subprojects.overview.indexTitle = Amber Web Authorization Framework
+qhp.AmberWebAuthorization.subprojects.overview.title = Amber Web Authorization Framework Overview
+qhp.AmberWebAuthorization.subprojects.overview.indexTitle = Amber Web Authorization Framework Overview
 qhp.AmberWebAuthorization.subprojects.overview.type = manual
 qhp.AmberWebAuthorization.subprojects.qmltypes.title = QML Types
 qhp.AmberWebAuthorization.subprojects.qmltypes.indexTitle = Amber.Web.Authorization QML Types


### PR DESCRIPTION
Overlapping titles in project and subproject caused unwanted classes
to appear in TOC